### PR TITLE
Move prod dependencies out of devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "highwind",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Mock API express server",
   "main": "lib/mock_api.js",
   "scripts": {
@@ -25,17 +25,19 @@
     "babel-plugin-transform-object-assign": "^6.3.13",
     "babel-polyfill": "^6.3.14",
     "babel-preset-es2015": "^6.3.13",
-    "body-parser": "^1.14.2",
     "chai": "^3.4.1",
+    "mocha": "^2.3.4",
+    "nock": "^5.2.1",
+    "sinon": "^1.17.2",
+    "supertest": "^1.1.0"
+  },
+  "dependencies": {
+    "body-parser": "^1.14.2",
     "cors": "^2.7.1",
     "eslint": "^1.10.3",
     "express": "^4.13.3",
     "fs": "0.0.2",
-    "mocha": "^2.3.4",
-    "nock": "^5.2.1",
     "node-fetch": "^1.3.3",
-    "sinon": "^1.17.2",
-    "supertest": "^1.1.0",
     "url": "^0.11.0"
   }
 }


### PR DESCRIPTION
This PR moves `import`s necessary for `src/mock_api.js` to run out of `devDependencies` and into `dependencies`.