### PR TITLE
Add babel-polyfill to dependencies and serve overrides quietly

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "highwind",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Mock API express server",
   "main": "lib/mock_api.js",
   "scripts": {
@@ -23,7 +23,6 @@
     "babel-core": "^6.4.0",
     "babel-eslint": "^4.1.6",
     "babel-plugin-transform-object-assign": "^6.3.13",
-    "babel-polyfill": "^6.3.14",
     "babel-preset-es2015": "^6.3.13",
     "chai": "^3.4.1",
     "mocha": "^2.3.4",
@@ -32,6 +31,7 @@
     "supertest": "^1.1.0"
   },
   "dependencies": {
+    "babel-polyfill": "^6.3.14",
     "body-parser": "^1.14.2",
     "cors": "^2.7.1",
     "eslint": "^1.10.3",

--- a/src/mock_api.js
+++ b/src/mock_api.js
@@ -1,3 +1,4 @@
+import 'babel-polyfill';
 import express from 'express';
 import cors from 'cors';
 import fetch from 'node-fetch';
@@ -8,6 +9,7 @@ import fs from 'fs';
 let PROD_ROOT_URL;
 let FIXTURES_PATH;
 let QUERY_STRING_IGNORE;
+let QUIET_MODE;
 const SERVERS = {};
 const REQUIRED_CONFIG_OPTIONS = [
   'prodRootURL',
@@ -39,6 +41,7 @@ module.exports = {
     PROD_ROOT_URL = prodRootURL;
     FIXTURES_PATH = fixturesPath;
     QUERY_STRING_IGNORE = queryStringIgnore;
+    QUIET_MODE = quiet;
 
     if (corsWhitelist) {
       setCorsMiddleware(app, corsWhitelist);
@@ -53,7 +56,7 @@ module.exports = {
         if (err) {
           recordFromProd(req, res);
         } else {
-          serveLocalResponse(res, fileName, data, { quiet: quiet });
+          serveLocalResponse(res, fileName, data, { quiet: QUIET_MODE });
         }
       });
     });
@@ -158,7 +161,9 @@ function delegateRouteOverrides(app, overrides, encoding) {
       }
 
       app[method].call(app, route, jsonMiddleware, (req, res) => {
-        console.info(`==> 📁  Serving local fixture for ${method.toUpperCase()} -> '${route}'`);
+        if (!QUIET_MODE) {
+          console.info(`==> 📁  Serving local fixture for ${method.toUpperCase()} -> '${route}'`);
+        }
         const payload = responseIsJson && typeof mergeParams === 'function'
           ? mergeParams(JSON.parse(fixture), req.body)
           : fixture;


### PR DESCRIPTION
This fixes an ES5 compilation issue in which Babel was transpiling our syntax but failing to provide a polyfill for `String.prototype.includes`.

I also configured `delegateRouteOverrides()` to not output to console when serving locally in quiet mode.