### PR TITLE
[DIS-1423] Add callbacks to .start() and .close() and perform some additional cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
 .DS_Store
+npm-debug.log
 
 lib

--- a/README.md
+++ b/README.md
@@ -22,7 +22,12 @@ const options = {
 };
 
 // booting your server
-highwind.start(options, [callback]);
+highwind.start(options, (err, result) => {
+  // 'result.app' is the instance of express
+  //
+  // 'result.servers' represents all currently running Highwind servers,
+  // and is an object with signature { port : server }.
+});
 
 // closing your server
 highwind.close();

--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ highwind.start(options, (err, result) => {
 // closing your server
 
 // first argument is an optional array of servers with the same signature
-// as highwind.start's `result.servers`
+// as highwind.start's `result.servers`. If this param is not passed in,
+// highwind.close will close all currently running servers.
 highwind.close(null, (err) => {
   // do something after all currently running servers have been closed
 });

--- a/README.md
+++ b/README.md
@@ -23,14 +23,27 @@ const options = {
 
 // booting your server
 highwind.start(options, (err, result) => {
-  // 'result.app' is the instance of express
+  // 'result.app' is the express object
   //
   // 'result.servers' represents all currently running Highwind servers,
-  // and is an object with signature { port : server }.
+  // and is an array of server objects with signature:
+  // {
+  //   port : number
+  //   server : instance of the express object in 'result.app'
+  //   active : bool
+  // }
+  //
+  // The important thing to note is that by the time the callback is called,
+  // result[n].server is currently listening for requests.
 });
 
 // closing your server
-highwind.close();
+
+// first argument is an optional array of servers with the same signature
+// as highwind.start's `result.servers`
+highwind.close(null, (err) => {
+  // do something after all currently running servers have been closed
+});
 ```
 
 Highwind only needs to know your the root URL for your production API and the

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ const options = {
 };
 
 // booting your server
-highwind.start(options);
+highwind.start(options, [callback]);
 
 // closing your server
 highwind.close();

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "supertest": "^1.1.0"
   },
   "dependencies": {
+    "async": "^1.5.2",
     "babel-polyfill": "^6.3.14",
     "body-parser": "^1.14.2",
     "cors": "^2.7.1",

--- a/spec/mock_api_spec.js
+++ b/spec/mock_api_spec.js
@@ -19,7 +19,7 @@ const DEFAULT_OPTIONS = {
   quiet: true
 };
 
-describe('#start', function() {
+describe('start()', function() {
   describe('Initialization', function() {
     it('throws an error when a prodRootURL or fixturesPath are not specified', function() {
       expect(() => {
@@ -297,9 +297,9 @@ describe('#start', function() {
   });
 });
 
-describe('#close', function() {
+describe('close()', function() {
   describe('without arguments', function() {
-    it('closes and garbage collects all servers instantiated by start', function() {
+    it('closes and garbage collects all servers instantiated by start()', function() {
       const ports = [1000, 2000, 3000];
       const modOptions = Object.assign({}, DEFAULT_OPTIONS, { ports: ports });
       const { servers } = start(modOptions);
@@ -313,7 +313,7 @@ describe('#close', function() {
       });
     });
 
-    it('throws an error unless start has been previously invoked', function() {
+    it('throws an error unless start() has been previously invoked', function() {
       expect(close).to.throw(Error);
     });
   });

--- a/spec/mock_api_spec.js
+++ b/spec/mock_api_spec.js
@@ -23,8 +23,8 @@ describe('start()', function() {
   describe('Initialization', function() {
     it('calls the passed in callback with an error when fixturesPath is not specified', function(done) {
       start({
-        prodRootURL: 'http://www.refinery29.com',
-      }, (err, result) => {
+        prodRootURL: 'http://www.refinery29.com'
+      }, (err) => {
         expect(err).to.be.an('error');
         done();
       });
@@ -32,8 +32,8 @@ describe('start()', function() {
 
     it('calls the passed in callback with an error when prodRootUrl is not specified', function(done) {
       start({
-        fixturesPath: './fixtures',
-      }, (err, result) => {
+        fixturesPath: './fixtures'
+      }, (err) => {
         expect(err).to.be.an('error');
         done();
       });
@@ -325,7 +325,7 @@ describe('close()', function() {
     });
   });
 
-  describe('when there are only inactive servers', function(done) {
+  describe('when there are only inactive servers', function() {
     before(function(done) {
       const ports = [5000, 5001, 5002];
       const modOptions = Object.assign({}, DEFAULT_OPTIONS, { ports });

--- a/spec/mock_api_spec.js
+++ b/spec/mock_api_spec.js
@@ -299,18 +299,19 @@ describe('start()', function() {
 
 describe('close()', function() {
   describe('without arguments', function() {
-    it('closes and garbage collects all servers instantiated by start()', function() {
-      const ports = [1000, 2000, 3000];
+    it('closes and garbage collects all servers instantiated by start()', function(done) {
+      const ports = [1111, 1112, 1113];
       const modOptions = Object.assign({}, DEFAULT_OPTIONS, { ports: ports });
       const { servers } = start(modOptions);
       const closedServers = [];
 
       ports.forEach(port => servers[port].on('close', () => closedServers.push(port)));
       close();
-      global.setInterval(1, () => {
+      global.setTimeout(() => {
         expect(ports).to.deep.equal(closedServers);
         expect(servers).to.deep.equal({});
-      });
+        done();
+      }, 1);
     });
 
     it('throws an error unless start() has been previously invoked', function() {
@@ -319,7 +320,7 @@ describe('close()', function() {
   });
 
   describe('with arguments', function() {
-    it('closes and garbage collects all servers passed to it', function() {
+    it('closes and garbage collects all servers passed to it', function(done) {
       const mockServer = {
         close() {}
       };
@@ -329,9 +330,10 @@ describe('close()', function() {
       };
       expect(mockServer.close).to.have.been.called;
       close(servers);
-      global.setInterval(1, () => {
+      global.setTimeout(() => {
         expect(servers).to.deep.equal({});
-      });
+        done();
+      }, 1);
     });
   });
 });

--- a/src/mock_api.js
+++ b/src/mock_api.js
@@ -96,8 +96,6 @@ module.exports = {
 }
 
 function generateMissingParamsError(options, callback) {
-  let error;
-
   if (typeof callback !== 'function') {
     return new Error('Missing callback');
   }

--- a/src/mock_api.js
+++ b/src/mock_api.js
@@ -17,7 +17,7 @@ const REQUIRED_CONFIG_OPTIONS = [
 ];
 
 module.exports = {
-  start(options) {
+  start(options, callback) {
     throwIfMissingOptions(options);
     const app = express();
     const defaults = {
@@ -49,6 +49,7 @@ module.exports = {
     if (overrides) {
       delegateRouteOverrides(app, overrides, encoding);
     }
+
     app.get('*', (req, res) => {
       const path = getURLPathWithQueryString(req);
       const fileName = getFileName(path);
@@ -60,7 +61,12 @@ module.exports = {
         }
       });
     });
+
     startListening(app, ports);
+
+    if (typeof callback === 'function') {
+      callback();
+    }
     return {
       app: app,
       servers: SERVERS
@@ -71,7 +77,7 @@ module.exports = {
     const servers = clientServers || SERVERS;
     const ports = Object.keys(servers);
     if (!ports.length) {
-      throw Error('closeMockAPI invoked without arguments or open servers');
+      throw Error('close() invoked without arguments or open servers');
     }
     ports.forEach(port => {
       console.info(`Closing mock API server on port ${port}`);


### PR DESCRIPTION
This PR:
- [X] Adds a callback to `.start()` (fixes #6)
- [X] Adds a callback to `.close()` (fixes #8)
- [X] Fixes up unit tests
- [X] Swaps references for `startMockAPI` and `closeMockAPI` to `.start()` and `.close()` respectively