### PR TITLE
Remove `fs` dependency in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "highwind",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Mock API express server",
   "main": "lib/mock_api.js",
   "scripts": {
@@ -37,7 +37,6 @@
     "cors": "^2.7.1",
     "eslint": "^1.10.3",
     "express": "^4.13.3",
-    "fs": "0.0.2",
     "node-fetch": "^1.3.3",
     "url": "^0.11.0"
   }


### PR DESCRIPTION
See: https://github.com/douah/bcrypt-pipe/pull/1

Summary: `fs` is now part of Node stdlib and direct importation is no longer necessary.