### PR TITLE
Add latency option

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ These are dropped in to the options object passed to `highwind.start()` during i
 * `saveFixtures`: *(boolean)*
   * **Default:** `true`.
   * Toggles persisting responses from the production API as local fixtures.
+* `latency`: *(number)*
+  * **Default:** 0
+  * Number of milliseconds to delay responses in order to simulate latency.
 
 ## HTTP Route Overrides
 Here are some examples of HTTP route overrides and their use cases.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "highwind",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Mock API express server",
   "main": "lib/mock_api.js",
   "scripts": {


### PR DESCRIPTION
**This PR:**
- [x] Adds `latency: number` config option
- When enabled, introduces _n_ ms delay between route match and response to simulate latency
