### PR TITLE
Add query param support to route overrides

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,9 @@
 {
-  "presets": ["es2015"],
-  "plugins": ["transform-object-rest-spread"]
+  "presets": [
+    "es2015"
+  ],
+  "plugins": [
+    "transform-object-rest-spread",
+    "transform-object-entries"
+  ]
 }

--- a/README.md
+++ b/README.md
@@ -139,6 +139,24 @@ This configures the mock API to respond to `get` requests for `/legacy_route` wi
 
 N.B.: Under the hood, the `headers` object is passed to Express's `response.set()` method. That means you can specify any HTTP header key/value pairs you'd like here, not just `'Content-Type'`.
 
+### Serving a JSON response with dynamic query params
+```js
+overrides: {
+  get: [
+    {
+      route: '/api/search',
+      withQueryParams: { query: 'foo' },
+      response: {
+        keyword: 'foo',
+        result_count: 15
+      },
+      status: 200
+    }
+  ]
+}
+```
+This serves the specified response _only_ when the query string matches the params specified in the `withQueryParams` object; in all other cases, it defers to the default response.
+
 ## Serving a JSONP response
 
 Highwind serves all routes with a `callback` specified in the query string as JSONP by default. This is easy to disable, though, either by specifying a non-JS `'Content-Type'` header in an override for a specific route or by adding something like `/callback\=([^\&]+)/` to your `queryStringIgnore` collection.

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "babel-cli": "^6.4.0",
     "babel-core": "^6.4.0",
     "babel-eslint": "^4.1.6",
+    "babel-plugin-transform-object-entries": "^1.0.0",
     "babel-plugin-transform-object-rest-spread": "^6.8.0",
     "babel-preset-es2015": "^6.3.13",
     "chai": "^3.4.1",


### PR DESCRIPTION
**This PR:**

- [x] Adds query param support to route overrides
- [x] Swaps indexed `for in` with `for of`
- [x] Adds [`Object.entries`](https://github.com/tc39/proposal-object-values-entries) support to Babel pipeline

**Usage:**

See update in [`README`](https://github.com/refinery29/highwind/blob/a363b9a927bc9c664134077fac6453187665e112/README.md#serving-a-json-response-with-dynamic-query-params).