### PR TITLE
[SHOP-908] Fix "saveFixtures" bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "highwind",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Mock API express server",
   "main": "lib/mock_api.js",
   "scripts": {

--- a/spec/mock_api_spec.js
+++ b/spec/mock_api_spec.js
@@ -139,11 +139,15 @@ describe('start()', function() {
               request(mockAPI.app)
                 .get(route)
                 .expect('Content-Type', /application\/json/)
-                .expect(200, response, () => fs.access(responsePath, fs.F_OK, (err) => {
-                  if (err) {
-                    done();
-                  }
-                }));
+                .expect(200)
+                .end((err, res) => {
+                  expect(res.text).to.equal(JSON.stringify(response));
+                  fs.access(responsePath, fs.F_OK, (err) => {
+                    if (err) {
+                      done();
+                    }
+                  });
+                });
             });
           });
         });

--- a/spec/mock_api_spec.js
+++ b/spec/mock_api_spec.js
@@ -70,7 +70,6 @@ describe('start()', function() {
         const responsePathWithCallback = RESPONSES_DIR + route + JSONP_CALLBACK + '.json';
 
         describe('When the request method is GET', function() {
-
           describe('And the saveFixtures setting is set to true', function() {
             beforeEach(function(done) {
               nock(PROD_ROOT_URL)
@@ -100,21 +99,33 @@ describe('start()', function() {
               request(mockAPI.app)
                 .get(route)
                 .expect('Content-Type', /application\/json/)
-                .expect(200, response, () => fs.access(responsePath, fs.F_OK, done));
+                .expect(200)
+                .end((err, res) => {
+                  expect(res.text).to.equal(JSON.stringify(response));
+                  fs.access(responsePath, fs.F_OK, done);
+                });
             });
 
             it('truncates ignored query string expressions in the persisted response filename', function(done) {
               request(mockAPI.app)
                 .get(route + IGNORED_QUERY_PARAMS)
                 .expect('Content-Type', /application\/json/)
-                .expect(200, response, () => fs.access(responsePath, fs.F_OK, done));
+                .expect(200)
+                .end((err, res) => {
+                  expect(res.text).to.equal(JSON.stringify(response));
+                  fs.access(responsePath, fs.F_OK, done);
+                });
             });
 
             it('renders the endpoint as JSONP when a callback is specified in the query string', function(done) {
               request(mockAPI.app)
                 .get(route + JSONP_CALLBACK)
                 .expect('Content-Type', /application\/javascript/)
-                .expect(200, response, () => fs.access(responsePathWithCallback, fs.F_OK, done));
+                .expect(200)
+                .end((err, res) => {
+                  expect(res.text).to.equal(JSON.stringify(response));
+                  fs.access(responsePathWithCallback, fs.F_OK, done);
+                });
             });
           });
 
@@ -144,8 +155,11 @@ describe('start()', function() {
                   expect(res.text).to.equal(JSON.stringify(response));
                   fs.access(responsePath, fs.F_OK, (err) => {
                     if (err) {
-                      done();
+                      return done();
                     }
+                    throw new Error(
+                      'Saved a fixture with saveFixtures set to false'
+                    );
                   });
                 });
             });

--- a/src/mock_api.js
+++ b/src/mock_api.js
@@ -246,11 +246,11 @@ function fetchResponse(req, res, options) {
         throw Error(`Couldn't complete fetch with Content-Type '${contentType}'`);
       }
     })
-    .then(response => {
+    .then(data => {
       if (saveFixtures) {
-        saveFixture(fileName, response, responseIsJson);
+        saveFixture(fileName, data, responseIsJson);
       }
-      serveResponse(res, { ...options, newResponse: true });
+      serveResponse(res, { ...options, data, newResponse: true });
     })
     .catch(err => {
       console.error(`==> ⛔️  ${err}`);


### PR DESCRIPTION
**This PR:**
- [x] Fixes a bug in which `saveFixtures` was not properly delegating the response as `data` to the client
- [x] Swaps `expect/3` for `expect/1` -> `end/1` in some of our unit tests (which hadn't been properly assessing the response before - this is why we hadn't caught the bug until just now!)
- [x] Bumps the version up to 1.0.4

Will be followed up by a version bump PR in https://github.com/refinery29/rosetta, fixing SHOP-908