### PR TITLE
Bump package to 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,4 +162,4 @@ This serves the specified response _only_ when the query string matches the para
 Highwind serves all routes with a `callback` specified in the query string as JSONP by default. This is easy to disable, though, either by specifying a non-JS `'Content-Type'` header in an override for a specific route or by adding something like `/callback\=([^\&]+)/` to your `queryStringIgnore` collection.
 
 ## License
-[MIT License](http://mit-license.org/) © Refinery29, Inc. 2016-2017
+[MIT License](http://mit-license.org/) © Refinery29, Inc. 2016-2018

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "highwind",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "Mock API express server",
   "main": "lib/mock_api.js",
   "scripts": {


### PR DESCRIPTION
This update has breaking changes, therefore we will do a major version bump.

* Bumps version in `package.json`
* Updates license year in `README`

Mimics https://github.com/refinery29/highwind/pull/17/files